### PR TITLE
Add announcement for CFP extension for UCA26

### DIFF
--- a/content/post/uca26-cfp-extended/index.md
+++ b/content/post/uca26-cfp-extended/index.md
@@ -1,0 +1,36 @@
+---
+date: 2026-04-08T12:44:00+05:45
+title: "UbuCon Asia 2026 Call for Proposals extended until April 24th"
+tags:
+  - ubucon
+  - uca26
+  - cfp
+forum_username: saileshsingh36
+authors:
+    - name: Sailesh Singh
+      bio: Organizer - UbuCon Asia & Ubuntu Nepal LoCo
+      email: saileshsingh@gnome.org
+      launchpad: saileshsingh36
+      github: Sailesh-Singh
+      profile: https://avatars2.githubusercontent.com/u/58818777?s=460&v=4
+draft: false
+---
+
+We’re happy to announce that we’re extending the **Call for Proposals deadline until April 24th**.
+
+If you were rushing to submit your proposal before the deadline, you now have some extra time to complete your submission. This is the **final CFP extension**, and there will be no further deadline extension after April 24th due to the visa invitation process and travel grant review timeline.
+
+If you need a travel grant from the organizing committee, please also make sure to submit your application before the CFP deadline. This helps us review your session proposal and travel grant application together and confirm your participation more smoothly later.
+
+Got an interesting topic to share in **Taipei**?  
+[Click here to submit your proposal today.](https://events.canonical.com/event/146/abstracts/)
+
+## Got questions?
+
+If you need help preparing your proposal, or are unsure whether your topic fits, please feel free to contact us or ask questions on chat:
+
+- Telegram: [https://t.me/UbuConAsia](https://t.me/UbuConAsia)
+- Matrix: [https://matrix.to/#/#ubucon-asia:ubuntu.com](https://matrix.to/#/#ubucon-asia:ubuntu.com)
+- Email: Content team - [content@ubucon.asia](mailto:content@ubucon.asia)
+
+We look forward to your proposals!


### PR DESCRIPTION
This PR adds the UbuCon Asia 2026 CFP extension announcement.

The deadline has been extended to April 24th, and the post also reminds applicants to submit travel grant requests before the CFP deadline if they need funding support.